### PR TITLE
Fix: IncludeInvisible set to false includes invisible child elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -667,6 +667,16 @@ const _finishCollisionShape = function(collisionShape, options, scale) {
   collisionShape.localTransform = localTransform;
 };
 
+const isObjectVisible = (object) => {
+  if (!object.visible) return false
+  
+  if (object.parent) {
+    return isObjectVisible(object.parent)
+  }
+  
+  return true
+}
+
 export const iterateGeometries = (function() {
   const inverse = new THREE.Matrix4();
   return function(root, options, cb) {
@@ -676,7 +686,7 @@ export const iterateGeometries = (function() {
       if (
         mesh.isMesh &&
         mesh.name !== "Sky" &&
-        (options.includeInvisible || (mesh.el && mesh.el.object3D.visible) || mesh.visible)
+        (options.includeInvisible || isObjectVisible(mesh))
       ) {
         if (mesh === root) {
           transform.identity();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c-frame/three-to-ammo",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Convert THREE.Mesh to Ammo.btCollisionShape",
   "homepage": "https://github.com/infinitelee/three-to-ammo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "three.js"
   ],
   "scripts": {
-    "test": "webpack-dev-server --mode=development"
+    "test": "webpack-dev-server --mode=development",
+    "test-legacy": "export NODE_OPTIONS=--openssl-legacy-provider && npm run test"
   },
   "peerDependencies": {
     "ammo.js": "*",


### PR DESCRIPTION
This PR to addresses the [issue](https://github.com/c-frame/aframe-physics-system/issues/66) where invisible child elements are included in the ammo shape even if "includeInvisible" is set to false.

This fix was made with a example code from @diarmidmackenzie in the isseu mentioned above. [issue](https://github.com/c-frame/aframe-physics-system/issues/66#issuecomment-3447594881) . 
Using a recursive function, we check if any child mesh is visible or not.

This PR closes the following issue: [issue](https://github.com/c-frame/aframe-physics-system/issues/66).

**Tests**
Adjustments to the package.json scrips had to be made to be able to run the tests.
To ensure tests run correctly in modern Node.js environments (v17+), I've updated the package.json test script to include the necessary flag: `"test": "export NODE_OPTIONS=--openssl-legacy-provider && npm run test"`

I've also locally tested the integration of this PR with the last version of aframe-physics-system by builind it locally. This way i was able to confirm this fixes the issue mentioned.

I kindly ask the maintainers to review and integrate this update. Once merged and a new version of three-to-ammo is released, the fix can be pulled into aframe-physics-system to resolve this issue.

Thank you for your review!