### PR TITLE
fixed includeInvisible previous changes to mitigate wasm memory error

### DIFF
--- a/index.js
+++ b/index.js
@@ -667,16 +667,15 @@ const _finishCollisionShape = function(collisionShape, options, scale) {
   collisionShape.localTransform = localTransform;
 };
 
-const isObjectVisible = (object) => {
+const isObjectVisibleUpToRoot = (object, root) => {
   if (!object.visible) return false
   
-  if (object.parent) {
-    return isObjectVisible(object.parent)
+  if (object.parent && object.parent !== root) {
+    return isObjectVisibleUpToRoot(object.parent)
   }
   
   return true
 }
-
 export const iterateGeometries = (function() {
   const inverse = new THREE.Matrix4();
   return function(root, options, cb) {
@@ -686,7 +685,7 @@ export const iterateGeometries = (function() {
       if (
         mesh.isMesh &&
         mesh.name !== "Sky" &&
-        (options.includeInvisible || isObjectVisible(mesh))
+        (options.includeInvisible || isObjectVisibleUpToRoot(mesh, root))
       ) {
         if (mesh === root) {
           transform.identity();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "three-to-ammo",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c-frame/three-to-ammo",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Convert THREE.Mesh to Ammo.btCollisionShape",
   "homepage": "https://github.com/infinitelee/three-to-ammo",
   "main": "index.js",


### PR DESCRIPTION
Based on the discussion of https://github.com/c-frame/aframe-physics-system/pull/67, this pull request fixes the changes made in https://github.com/c-frame/three-to-ammo/pull/6. This previous PR exposed a pre-existing issue in the library that resulted in a wasm memory error.

This fix was made with the code example of @diarmidmackenzie in https://github.com/c-frame/aframe-physics-system/pull/67#issuecomment-3516206407.

